### PR TITLE
Use master travis-scripts branch instead of ws-builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,13 +27,12 @@ before_install:
   -in github_deploy.pem.enc -out github_deploy.pem -d
 - pip install --user awscli
 install:
-- git clone https://github.com/aws-robotics/travis-scripts.git
-  .ros_ci
+- git clone https://github.com/aws-robotics/travis-scripts.git .ros_ci
 script:
-- ". .ros_ci/add_tag.sh"
-- ".ros_ci/ce_build.sh"
+- . .ros_ci/add_tag.sh
+- travis_wait 50 .ros_ci/ce_build.sh
 before_deploy:
-- ". .ros_ci/before_deploy.sh"
+- . .ros_ci/before_deploy.sh
 deploy:
 - provider: s3
   access_key_id: "$AWS_ACCESS_KEY_ID"
@@ -50,4 +49,4 @@ deploy:
   on:
     branch: master
 after_deploy:
-- ".ros_ci/post_deploy.sh"
+- .ros_ci/post_deploy.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_install:
   -in github_deploy.pem.enc -out github_deploy.pem -d
 - pip install --user awscli
 install:
-- git clone --branch ws-builds https://github.com/aws-robotics/travis-scripts.git
+- git clone https://github.com/aws-robotics/travis-scripts.git
   .ros_ci
 script:
 - ". .ros_ci/add_tag.sh"


### PR DESCRIPTION
This will make travis only build `simulation_ws` and skip `robot_ws` (which doesn't build without an AWS account set, and isn't needed for simulation testing). It will only build `simulation_ws` because the master `travis-scripts` branch uses the environment variable `WORKSPACES` to determine what workspaces should be built. 

Also adding travis_wait and cleaning up the .travis.yml file. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
