### PR TITLE
Use official port of xacro

### DIFF
--- a/simulation_ws/.rosinstall
+++ b/simulation_ws/.rosinstall
@@ -1,1 +1,1 @@
-- git: {local-name: src/deps/xacro, uri: "https://github.com/AAlon/xacro", version: ros2-find}
+- git: {local-name: src/deps/xacro, uri: "https://github.com/ros/xacro", version: 2.0.1}


### PR DESCRIPTION
Will be able to remove this altogether once 2.0.1 is in apt: http://repo.ros2.org/status_page/ros_dashing_default.html?q=xacro

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
