### PR TITLE
Bump tensorflow from 1.12.2 to 1.15.0 in robot_ws

### DIFF
--- a/robot_ws/src/turtlebot_controller/setup.py
+++ b/robot_ws/src/turtlebot_controller/setup.py
@@ -18,13 +18,13 @@ setup(
         'gym==0.10.5',
         'matplotlib==2.0.2',
         'netifaces==0.10.7',
-        'numpy==1.13.3',
+        'numpy==1.17.4',
         'pandas==0.20.2',
         'Pillow==4.3.0',
         'PyYAML==4.2b1',
         'scipy==0.19.0',
         'scikit-image==0.13.0',
-        'tensorflow==1.11',
+        'tensorflow==1.15.0',
         'rospkg==1.1.7',
     ]
 )


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
