### PR TITLE
Remove turtlebot3 packages from .rosinstall

### DIFF
--- a/simulation_ws/.rosinstall
+++ b/simulation_ws/.rosinstall
@@ -1,1 +1,0 @@
-- git: {local-name: src/deps/turtlebot3_simulations, uri: "https://github.com/ROBOTIS-GIT/turtlebot3_simulations", version: 1.2.0}


### PR DESCRIPTION
*Description of changes:*

In the same vein as https://github.com/aws-robotics/aws-robomaker-sample-application-cloudwatch/pull/67 and https://github.com/aws-robotics/aws-robomaker-sample-application-persondetection/pull/66, this removes `turtlebot3` packages from the `.rosinstall` file, so that these packages are no longer obtained by source code through `rosws update`, but rather directly by binary through `rosdep install`, which should be the preferred method.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
